### PR TITLE
Remove unnecessary particule in FR

### DIFF
--- a/fr.json
+++ b/fr.json
@@ -78,7 +78,7 @@
   "colors.ruby": "Rubis",
   "colors.white": "Blanc",
   "content_tools.button": "Bouton",
-  "content_tools.columns": "Les colonnes",
+  "content_tools.columns": "Colonnes",
   "content_tools.divider": "Séparateur",
   "content_tools.form": "Formulaire",
   "content_tools.heading": "Titre",


### PR DESCRIPTION
In French, the particule "Les" is unnecessary for uncountable amounts (same as in English: "the columns", meaning a specific number of columns, vs "columns", meaning the concept of columns in general).

Having it in French feels a bit weird (not appropriate for a button), doesn't match with other buttons ("Bouton", "Séparateur", ...) and complexify display.

I suggest removing the particule.