### PR TITLE
Fix ja-JP translation

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -375,7 +375,7 @@
   "labels.words": "単語",
   "modals.category.invalid": "これは無効なカテゴリ名です",
   "modals.category.placeholder": "カテゴリ名",
-  "modals.delete.columns": "{columns,number}{columns,plural,one{column}other{columns}}が失われます。よろしいですか？",
+  "modals.delete.columns": "{columns,number}列が失われます。よろしいですか？",
   "modals.delete.confirmation": "これを削除してもよろしいですか？このアクションは元に戻せません。",
   "modals.delete.title": "削除",
   "modals.display_conditions.title": "表示条件を選択してください",


### PR DESCRIPTION
Improves the Japanese translation for a more accurate phrasing in the context of deleting a column.  The updated translation ensures a better user experience for Japanese speakers and enhances the overall quality of the localization.

### Before
<img width="325" alt="截圖 2023-04-25 下午7 13 27" src="https://user-images.githubusercontent.com/32828379/234260047-28e0e295-be8e-41ca-8848-9f85f42a9944.png">


### After
<img width="301" alt="截圖 2023-04-25 下午7 09 24" src="https://user-images.githubusercontent.com/32828379/234259917-c08afff1-1b76-4836-9a99-0eae9f2928db.png">
